### PR TITLE
Constant-time

### DIFF
--- a/code/jasmin/avx2/Makefile
+++ b/code/jasmin/avx2/Makefile
@@ -91,7 +91,10 @@ test/test_polyvec_%: test/test_polyvec_%.c $(HEADERS) $(SOURCES) $(INCS) jpolyve
 %.s: %.jazz
 	$(JASMIN) -o $@ $(JFLAGS) $^
 
-.PHONY: clean
+.PHONY: clean ct
+
+ct:
+	$(JASMIN) -checkCT -infer jkem.jazz
 
 clean:
 	-rm -f *.o

--- a/code/jasmin/avx2/indcpa.jinc
+++ b/code/jasmin/avx2/indcpa.jinc
@@ -21,6 +21,7 @@ fn __indcpa_keypair(reg u64 pkp, reg u64 skp, reg ptr u8[KYBER_SYMBYTES] randomn
 
   for i=0 to KYBER_SYMBYTES/8
   {
+    #declassify
     t64 = randomnessp[u64 i];
     inbuf[u64 i] = t64;
   }
@@ -91,6 +92,7 @@ fn __indcpa_enc_0(stack u64 sctp, reg ptr u8[KYBER_INDCPA_MSGBYTES] msgp, reg u6
   pkp += KYBER_POLYVECBYTES;
   while (i < KYBER_SYMBYTES/8)
   {
+    #declassify
     t64 = (u64)[pkp];
     publicseed.[u64 8 * (int)i] = t64;
     pkp += 8;
@@ -155,6 +157,7 @@ fn __indcpa_enc_1(reg ptr u8[KYBER_INDCPA_CIPHERTEXTBYTES] ctp, reg ptr u8[KYBER
   pkp += KYBER_POLYVECBYTES;
   while (i < KYBER_SYMBYTES/8)
   {
+    #declassify
     t64 = (u64)[pkp];
     publicseed.[u64 8*(int)i] = t64;
     pkp += 8;

--- a/code/jasmin/avx2v/Makefile
+++ b/code/jasmin/avx2v/Makefile
@@ -91,7 +91,10 @@ test/test_polyvec_%: test/test_polyvec_%.c $(HEADERS) $(SOURCES) $(INCS) jpolyve
 %.s: %.jazz
 	$(JASMIN) -o $@ $(JFLAGS) $^
 
-.PHONY: clean
+.PHONY: clean ct
+
+ct:
+	$(JASMIN) -checkCT -infer jkem.jazz
 
 clean:
 	-rm -f *.o

--- a/code/jasmin/avx2v/indcpa.jinc
+++ b/code/jasmin/avx2v/indcpa.jinc
@@ -21,6 +21,7 @@ fn __indcpa_keypair(reg u64 pkp, reg u64 skp, reg ptr u8[KYBER_SYMBYTES] randomn
 
   for i=0 to KYBER_SYMBYTES/8
   {
+    #declassify
     t64 = randomnessp[u64 i];
     inbuf[u64 i] = t64;
   }
@@ -91,6 +92,7 @@ fn __indcpa_enc_0(stack u64 sctp, reg ptr u8[KYBER_INDCPA_MSGBYTES] msgp, reg u6
   pkp += KYBER_POLYVECBYTES;
   while (i < KYBER_SYMBYTES/8)
   {
+    #declassify
     t64 = (u64)[pkp];
     publicseed.[u64 8 * (int)i] = t64;
     pkp += 8;
@@ -155,6 +157,7 @@ fn __indcpa_enc_1(reg ptr u8[KYBER_INDCPA_CIPHERTEXTBYTES] ctp, reg ptr u8[KYBER
   pkp += KYBER_POLYVECBYTES;
   while (i < KYBER_SYMBYTES/8)
   {
+    #declassify
     t64 = (u64)[pkp];
     publicseed.[u64 8*(int)i] = t64;
     pkp += 8;

--- a/code/jasmin/ref/Makefile
+++ b/code/jasmin/ref/Makefile
@@ -78,7 +78,10 @@ test/test_polyvec_%: test/test_polyvec_%.c $(HEADERS) $(SOURCES) jpolyvec.s
 	$(JASMIN) -o $@ $(JFLAGS) $^ 
 
 
-.PHONY: clean
+.PHONY: clean ct
+
+ct:
+	$(JASMIN) -checkCT -infer jkem.jazz
 
 clean:
 	-rm -f *.s

--- a/code/jasmin/ref/indcpa.jinc
+++ b/code/jasmin/ref/indcpa.jinc
@@ -24,6 +24,7 @@ fn __indcpa_keypair(reg u64 pkp, reg u64 skp, reg ptr u8[KYBER_SYMBYTES] randomn
 
   for i=0 to KYBER_SYMBYTES/8
   {
+    #declassify
     t64 = randomnessp[u64 i];
     inbuf[u64 i] = t64;
   }
@@ -101,6 +102,7 @@ fn __indcpa_enc(stack u64 sctp, reg ptr u8[32] msgp, reg u64 pkp, reg ptr u8[KYB
   pkp += KYBER_POLYVECBYTES;
   while (i < KYBER_SYMBYTES/8)
   {
+    #declassify
     t64 = (u64)[pkp];
     publicseed.[u64 8 * (int)i] = t64;
     pkp += 8;
@@ -171,6 +173,7 @@ fn __iindcpa_enc(reg ptr u8[KYBER_CT_LEN] ctp, reg ptr u8[32] msgp, reg u64 pkp,
   pkp += KYBER_POLYVECBYTES;
   while (i < KYBER_SYMBYTES/8)
   {
+    #declassify
     t64 = (u64)[pkp];
     publicseed.[u64 8*(int)i] = t64;
     pkp += 8;


### PR DESCRIPTION
Adds `make ct` targets to check that the three main entry points are actually CT.

Adds a few `#declassify` annotations to express that the public key is actually public and that randomness is used securely.