### PR TITLE
gen_matrix.jinc: fix the order of “require” directives

### DIFF
--- a/code/jasmin/ref/gen_matrix.jinc
+++ b/code/jasmin/ref/gen_matrix.jinc
@@ -1,5 +1,5 @@
-require "fips202.jinc"
 require "params.jinc"
+require "fips202.jinc"
 
 inline
 fn __rej_uniform(stack u16[KYBER_N] rp, reg u64 offset, stack u8[SHAKE128_RATE] buf) ->  reg u64, stack u16[KYBER_N]

--- a/code/jasmin/ref/jfips202.jazz
+++ b/code/jasmin/ref/jfips202.jazz
@@ -1,3 +1,4 @@
+require "params.jinc"
 require "fips202.jinc"
 
 export fn shake256_128_33_jazz(reg u64 outp inp) 


### PR DESCRIPTION
This fixes the compilation of `gen_matrix.jazz` which currently fails.