### PR TITLE
poly ntt invntt scheduling

### DIFF
--- a/code/jasmin/mlkem_ref/extraction/jkem.ec
+++ b/code/jasmin/mlkem_ref/extraction/jkem.ec
@@ -1078,9 +1078,9 @@ module M(SC:Syscall_t) = {
     var zeta_0:W16.t;
     var j:W64.t;
     var cmp:W64.t;
+    var t:W16.t;
     var offset:W64.t;
     var s:W16.t;
-    var t:W16.t;
     var m:W16.t;
     zetasp <- witness;
     zetasp <- jzetas_inv;
@@ -1098,10 +1098,10 @@ module M(SC:Syscall_t) = {
         cmp <- (cmp + len);
         
         while ((j \ult cmp)) {
+          t <- rp.[(W64.to_uint j)];
           offset <- j;
           offset <- (offset + len);
           s <- rp.[(W64.to_uint offset)];
-          t <- rp.[(W64.to_uint j)];
           m <- s;
           m <- (m + t);
           m <@ __barrett_reduce (m);
@@ -1137,10 +1137,10 @@ module M(SC:Syscall_t) = {
     var zeta_0:W16.t;
     var j:W64.t;
     var cmp:W64.t;
-    var offset:W64.t;
-    var t:W16.t;
     var s:W16.t;
     var m:W16.t;
+    var offset:W64.t;
+    var t:W16.t;
     zetasp <- witness;
     zetasp <- jzetas;
     zetasctr <- (W64.of_int 0);
@@ -1157,15 +1157,15 @@ module M(SC:Syscall_t) = {
         cmp <- (cmp + len);
         
         while ((j \ult cmp)) {
+          s <- rp.[(W64.to_uint j)];
+          m <- s;
           offset <- j;
           offset <- (offset + len);
           t <- rp.[(W64.to_uint offset)];
           t <@ __fqmul (t, zeta_0);
-          s <- rp.[(W64.to_uint j)];
-          m <- s;
           m <- (m - t);
-          rp.[(W64.to_uint offset)] <- m;
           t <- (t + s);
+          rp.[(W64.to_uint offset)] <- m;
           rp.[(W64.to_uint j)] <- t;
           j <- (j + (W64.of_int 1));
         }

--- a/code/jasmin/mlkem_ref/poly.jinc
+++ b/code/jasmin/mlkem_ref/poly.jinc
@@ -486,9 +486,9 @@ fn _poly_invntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
       cmp = start; cmp += len;
       while (j < cmp)
       {
+        t = rp[(int)j];
         offset = j; offset += len;
         s = rp[(int)offset];
-        t = rp[(int)j];
         m = s; m += t;
         m = __barrett_reduce(m);
         rp[(int)j] = m;
@@ -544,14 +544,14 @@ fn _poly_ntt(reg ptr u16[MLKEM_N] rp) -> reg ptr u16[MLKEM_N]
       cmp = start; cmp += len;
       while (j < cmp)
       {
+        s = rp[(int)j];
+        m = s;
         offset = j; offset += len;
         t = rp[(int)offset];
         t = __fqmul(t, zeta);
-        s = rp[(int)j];
-        m = s;
         m -= t;
-        rp[(int)offset] = m;
         t += s;
+        rp[(int)offset] = m;
         rp[(int)j] = t;
         j += 1;
       }


### PR DESCRIPTION
this was done on top of the keccak branch (it should have been done differently).

The cycles improvements are the following:
```
keypair       , 220384 -> 213394
enc           , 267904 -> 261994
dec           , 339528 -> 330058
```
which help in closing the gap between the comparable C implementation from pq-crystals/kyber/standard (compiled with -mno-sse and bmi is also disabled):
```
keypair, 210982
enc    , 252650
dec    , 326310
```